### PR TITLE
Add first CI steps

### DIFF
--- a/ci.md
+++ b/ci.md
@@ -1,2 +1,9 @@
 # GitHub Flow
 
+1. Pull in the latest code. Create a branch from `master`. Start working.    
+2. Create commits on your new branch. Build and test locally.  
+  Pass? Go to the next step. Fail? Fix errors or tests and try again.  
+3. Push to your remote repository or remote branch.  
+4. Open a pull request. Discuss the changes, add more commits  
+  as discussion continues. Make tests pass on the feature branch.  
+

--- a/ci.test.js
+++ b/ci.test.js
@@ -11,8 +11,23 @@ describe('CI sequence', () => {
     expect(/.*#.*/ig.test(fileContents)).toBe(true);
   });
 
-  // TODO add the tests between these comments =>
+  
+  //    TODO add the tests between these comments =>
+  it('1. pull latest code', () => {
+    expect(/.*pull.*/ig.test(fileContents)).toBe(true);
+  });
 
+  it('2. add commits', () => {
+    expect(/.*commit.*/ig.test(fileContents)).toBe(true);
+  });
+
+  it('3. push to the remote branch with the same name', () => {
+    expect(/.*push.*/ig.test(fileContents)).toBe(true);
+  });
+
+  it('4. open a pull request and continue working', () => {
+    expect(/.*pull\s+request.*/ig.test(fileContents)).toBe(true);
+  });
   // TODO <= add the tests between these comments
 
 });


### PR DESCRIPTION
En este pull request probamos  Establecer feature-steps como rama principal y master como rama base.

En la jerga de GitHub, la rama "base" es la rama en la que basa su trabajo, y la rama "principal" es la rama con el trabajo que está fusionando.